### PR TITLE
Add a discordInfo command

### DIFF
--- a/src/commands/commandHandler.ts
+++ b/src/commands/commandHandler.ts
@@ -6,6 +6,7 @@ import { buildCommand as buildSc2Command } from "./starcraft2";
 import { Message, MessageEmbed } from "discord.js";
 import { AppConfig } from "../appConfig";
 import { RhobotCommand } from ".";
+import { discordInfoCommand } from "./discordInfo";
 
 type DiscordMessageHandler = (message: Message) => void;
 
@@ -72,6 +73,7 @@ export function buildCommandHandler(appConfig: AppConfig): DiscordMessageHandler
   const COMMAND_PREFIX = commandPrefix || "!";
   const COMMANDS: Record<string, RhobotCommand> = {
     lockdown: lockdownCommand,
+    discordInfo: discordInfoCommand,
     event:
       buildEventCommand({
         prefix: COMMAND_PREFIX,

--- a/src/commands/discordInfo.ts
+++ b/src/commands/discordInfo.ts
@@ -1,0 +1,35 @@
+import * as Discord from "discord.js";
+import { RhobotCommand } from ".";
+
+/**
+ * Replies with the calling Discord user's information.
+ */
+export const discordInfoCommand: RhobotCommand = {
+  run: (message) => {
+    message.channel.send(formatUserSummary(message.author));
+  },
+  help: "Show your Discord user info.",
+};
+
+/**
+ * Return a message embed of the Discord user's information.
+ *
+ * @param {Object} playerSummary - The player summary object returned from the API.
+ */
+function formatUserSummary(user: Discord.User) {
+  function orUnknown(maybeString) {
+    return maybeString || "Unkown";
+  }
+
+  const embed = new Discord.MessageEmbed();
+  embed.setTitle("Discord user information");
+  embed.addFields([
+    { name: "Username", value: orUnknown(user.username) },
+    { name: "Active since", value: orUnknown(user.createdAt.toISOString()) },
+  ]);
+
+  embed.setThumbnail(user.avatarURL() || user.defaultAvatarURL);
+
+  embed.setFooter(`ID: ${orUnknown(user.id)}`);
+  return embed;
+}


### PR DESCRIPTION
This command outputs information about a Discord user.
Specifically, it outputs the user ID which we'll need in order to
create some hard-coded lists of API keys later.

# Testing

Ran the bot locally.
![Screenshot 2020-09-20 095959](https://user-images.githubusercontent.com/6492251/93706599-18b4ff00-fb28-11ea-99cf-ade88737b96a.png)
